### PR TITLE
Updated missing dependencies in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,6 @@ numpy
 tensorflow
 spacy
 nltk
+text2text
+boto3
+sense2vec


### PR DESCRIPTION
For those trying to run on a 'vanilla' environment, sense2vec/boto3/text2text installation can be made easier by adding them to requirements.txt.